### PR TITLE
Fix syntax errors in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "homepage": "https://mohamedsuhailkhan.github.io/bokaap-deli-reserve-bite/"
+  "homepage": "https://mohamedsuhailkhan.github.io/bokaap-deli-reserve-bite/",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -63,8 +65,6 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
     "zod": "^3.23.8"
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
@@ -83,7 +83,8 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+.
+    "vite": "^5.4.1",
     "gh-pages": "^3.2.3"
   }
 }


### PR DESCRIPTION
This commit fixes several syntax errors in the package.json file that were preventing `npm install` from running correctly.

- Added a missing comma after the `homepage` property.
- Moved `predeploy` and `deploy` scripts into the `scripts` object.
- Added missing commas to the `dependencies` and `devDependencies` objects.